### PR TITLE
[FIX] fix circular dependency between website_subscription and subscr…

### DIFF
--- a/subscription_line_partner/__manifest__.py
+++ b/subscription_line_partner/__manifest__.py
@@ -34,5 +34,6 @@
         "views/product_template_view.xml",
         "views/subscription_form.xml",
         "views/subscription_portal.xml",
+        "security/ir_rules.xml",
     ],
 }

--- a/subscription_line_partner/security/ir_rules.xml
+++ b/subscription_line_partner/security/ir_rules.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <!-- website_subscription gets installed as this module's dependency.
+     Modify its record rule to take into account this module's new partner_id field.
+
+    Note: during next migration consider removing the website_subscription
+    dependency from this module, to support the use case of not having website
+    installed at all.
+     -->
+    <record id="website_subscription.sale_subscription_rule_portal" model="ir.rule">
+        <field name="domain_force">[
+            '|', '|', '|',
+            ('partner_id', '=', user.commercial_partner_id.id),
+            ('sale_subscription_line_ids.partner_id', '=', user.partner_id.id),
+            ('partner_id', '=', user.partner_id.id),
+            ('message_partner_ids', 'child_of', [user.commercial_partner_id.id])
+        ]</field>
+    </record>
+</odoo>

--- a/website_subscription/security/ir_rules.xml
+++ b/website_subscription/security/ir_rules.xml
@@ -6,9 +6,8 @@
         <field name="name">Portal Personal Subscriptions</field>
         <field name="model_id" ref="subscription_oca.model_sale_subscription" />
         <field name="domain_force">[
-            '|', '|', '|',
+            '|', '|',
             ('partner_id', '=', user.commercial_partner_id.id),
-            ('sale_subscription_line_ids.partner_id', '=', user.partner_id.id),
             ('partner_id', '=', user.partner_id.id),
             ('message_partner_ids', 'child_of', [user.commercial_partner_id.id])
         ]</field>


### PR DESCRIPTION
…iption_line_partner

- subscription_line_partner had (and still has) website_subscription in its dependencies, but website_subscription had an ir.rule that depended on subscription_line_partner, causing a crash when installing the modules into a new odoo installation
- moved the problematic rule condition to subscription_line_partner instead